### PR TITLE
fix: compilation error on macos linked to clang++ and lib++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 enable_testing()
 
 # =============================================
-# LLVM FIX FOR macOS + HOMEBREW LLVM BUG
+# fix for macOS + Homebrew LLVM bug
 # (__hash_memory missing symbol)
+# Force linking against Homebrew libc++ instead of Apple SDK libc++
 # =============================================
 if(APPLE)
     find_package(LLVM QUIET CONFIG)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -34,10 +34,11 @@ add_executable(${PROJECT_NAME}
         ${CLIENT_SOURCES}
 )
 
-# =============================================
-# FIX: macOS + Homebrew LLVM "__hash_memory" bug
-# Force linking with Homebrew libc++ instead of Apple SDK libc++
-# =============================================
+# -------------------------------------
+# fix for macOS + Homebrew LLVM bug
+# (__hash_memory missing symbol)
+# Force linking against Homebrew libc++ instead of Apple SDK libc++
+# -------------------------------------
 if (APPLE AND DEFINED LLVM_LIBCXX_DIR)
     target_link_directories(${PROJECT_NAME} PUBLIC ${LLVM_LIBCXX_DIR})
 endif()

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -28,10 +28,11 @@ add_executable(${PROJECT_NAME}
         ${SERVER_SOURCES}
 )
 
-# =============================================
-# FIX: macOS + Homebrew LLVM "missing __hash_memory"
+# -----------------------------
+# fix for macOS + Homebrew LLVM bug
+# (__hash_memory missing symbol)
 # Force linking against Homebrew libc++ instead of Apple SDK libc++
-# =============================================
+# -----------------------------
 if (APPLE AND DEFINED LLVM_LIBCXX_DIR)
     target_link_directories(${PROJECT_NAME} PUBLIC ${LLVM_LIBCXX_DIR})
 endif()


### PR DESCRIPTION
This pull request introduces a fix for a known macOS + Homebrew LLVM issue, specifically the missing `__hash_memory` symbol when building the project. The solution ensures that both the client and server components link against the correct Homebrew-provided `libc++` instead of the default Apple SDK version. Additionally, the main project configuration is updated to support both C and C++ languages.

macOS + Homebrew LLVM compatibility fixes:

* Updated the main `CMakeLists.txt` to detect LLVM on macOS, set the correct `libc++` directory from Homebrew, and cache its location for use in subprojects.
* Modified `client/CMakeLists.txt` and `server/CMakeLists.txt` to conditionally link the client and server targets against the Homebrew `libc++` directory if on macOS and LLVM is found, resolving the `__hash_memory` symbol issue. [[1]](diffhunk://#diff-8404a76cc315289a505a0b9e571242cb4f5ba0c122fb86382329a4b714425ac3R37-R45) [[2]](diffhunk://#diff-557b764d93c625467726335e930bdb5e8b625a3709e76d8afbcac860d455e5c8R31-R38)

Project configuration update:

* Changed the project declaration in `CMakeLists.txt` to support both C and C++ languages, ensuring broader compatibility.