### PR TITLE
feat: replace all usages of SparseArray operator[] with at() for safe bounds

### DIFF
--- a/server/src/ecs/systems/AI/AISystem.cpp
+++ b/server/src/ecs/systems/AI/AISystem.cpp
@@ -50,7 +50,7 @@ namespace Game
                         }
                         {
                             auto &posArr = reg.getComponents<Ecs::Position>();
-                            Ecs::Position playerPos = *posArr[tgt.targetId];
+                            Ecs::Position playerPos = *posArr.at(tgt.targetId);
 
                             float dx = playerPos.x - pos.x;
                             float dy = playerPos.y - pos.y;

--- a/server/src/ecs/systems/attackSystem/AttackSystem.cpp
+++ b/server/src/ecs/systems/attackSystem/AttackSystem.cpp
@@ -34,10 +34,10 @@ namespace Game
                 if (target.targetId == SIZE_MAX)
                     return;
                 auto &posArr = reg.getComponents<Ecs::Position>();
-                if (!posArr[target.targetId].has_value())
+                if (!posArr.at(target.targetId).has_value())
                     return;
 
-                Ecs::Position playerPos = *posArr[target.targetId];
+                Ecs::Position playerPos = *posArr.at(target.targetId);
 
                 float dx = playerPos.x - pos.x;
                 float dy = playerPos.y - pos.y;

--- a/server/src/ecs/systems/collision/CollisionSystem.cpp
+++ b/server/src/ecs/systems/collision/CollisionSystem.cpp
@@ -27,19 +27,19 @@ namespace Game
         std::vector<Ecs::Entity> toDestroy;
 
         for (size_t i = 0; i < posArr.size(); i++) {
-            if (!posArr[i].has_value() || !colArr[i].has_value())
+            if (!posArr.at(i).has_value() || !colArr.at(i).has_value())
                 continue;
 
             for (size_t j = i + 1; j < posArr.size(); j++) {
-                if (!posArr[j].has_value() || !colArr[j].has_value())
+                if (!posArr.at(j).has_value() || !colArr.at(j).has_value())
                     continue;
-                if (!intersects(*posArr[i], *colArr[i], *posArr[j], *colArr[j]))
+                if (!intersects(*posArr.at(i), *colArr.at(i), *posArr.at(j), *colArr.at(j)))
                     continue;
-                if (dmgArr[i].has_value() && hpArr[j].has_value()) {
-                    hpArr[j]->hp -= dmgArr[i]->amount;
+                if (dmgArr.at(i).has_value() && hpArr.at(j).has_value()) {
+                    hpArr.at(j)->hp -= dmgArr.at(i)->amount;
                     toDestroy.emplace_back(Ecs::Entity(i));
-                } else if (dmgArr[j].has_value() && hpArr[i].has_value()) {
-                    hpArr[i]->hp -= dmgArr[j]->amount;
+                } else if (dmgArr.at(j).has_value() && hpArr.at(i).has_value()) {
+                    hpArr.at(i)->hp -= dmgArr.at(j)->amount;
                     toDestroy.emplace_back(Ecs::Entity(j));
                 }
             }

--- a/server/src/ecs/systems/damage/DamageSystem.cpp
+++ b/server/src/ecs/systems/damage/DamageSystem.cpp
@@ -15,10 +15,10 @@ namespace Game
         auto &hpArr = reg.getComponents<Ecs::Health>();
 
         for (size_t i = 0; i < hpArr.size(); i++) {
-            if (!hpArr[i].has_value())
+            if (!hpArr.at(i).has_value())
                 continue;
 
-            if (hpArr[i]->hp <= 0) {
+            if (hpArr.at(i)->hp <= 0) {
                 reg.destroyEntity(Ecs::Entity(i));
             }
         }

--- a/server/src/ecs/systems/health/HealthSystem.cpp
+++ b/server/src/ecs/systems/health/HealthSystem.cpp
@@ -15,9 +15,9 @@ namespace Game
         auto &hpArr = reg.getComponents<Ecs::Health>();
 
         for (size_t i = 0; i < hpArr.size(); i++) {
-            if (!hpArr[i].has_value())
+            if (!hpArr.at(i).has_value())
                 continue;
-            if (hpArr[i]->hp <= 0)
+            if (hpArr.at(i)->hp <= 0)
                 reg.destroyEntity(Ecs::Entity(i));
         }
     }

--- a/server/src/ecs/systems/lifetime/LifetimeSystem.cpp
+++ b/server/src/ecs/systems/lifetime/LifetimeSystem.cpp
@@ -16,11 +16,11 @@ namespace Game
         auto &lifeArr = reg.getComponents<Ecs::Lifetime>();
 
         for (size_t i = 0; i < lifeArr.size(); i++) {
-            if (!lifeArr[i].has_value())
+            if (!lifeArr.at(i).has_value())
                 continue;
 
-            lifeArr[i]->remaining -= dt;
-            if (lifeArr[i]->remaining <= 0.f)
+            lifeArr.at(i)->remaining -= dt;
+            if (lifeArr.at(i)->remaining <= 0.f)
                 reg.destroyEntity(Ecs::Entity(i));
         }
     }

--- a/server/src/ecs/systems/targetSystem/TargetingSystem.cpp
+++ b/server/src/ecs/systems/targetSystem/TargetingSystem.cpp
@@ -17,13 +17,13 @@ namespace Game
 
         std::vector<size_t> players;
         for (size_t i = 0; i < ctrlArr.size(); ++i)
-            if (ctrlArr[i].has_value())
+            if (ctrlArr.at(i).has_value())
                 players.push_back(i);
         if (players.empty())
             return;
 
         const size_t playerId = players[Rand::rng() % players.size()];
-        const Ecs::Position &playerPos = *posArr[playerId];
+        const Ecs::Position &playerPos = *posArr.at(playerId);
         reg.view<Ecs::Target, Ecs::Position>([&](Ecs::Entity, Ecs::Target &tgt, const Ecs::Position &pos) {
             const float dx = playerPos.x - pos.x;
             const float dy = playerPos.y - pos.y;

--- a/server/src/game/gameServer/GameServer.cpp
+++ b/server/src/game/gameServer/GameServer.cpp
@@ -147,7 +147,7 @@ namespace Game
                 const Ecs::Entity ent = _sessionToEntity[cmd.sessionId];
                 auto &inputs = _worldWrite->registry().getComponents<InputComponent>();
 
-                if (auto &inputOpt = inputs[static_cast<size_t>(ent)]; inputOpt.has_value()) {
+                if (auto &inputOpt = inputs.at(static_cast<size_t>(ent)); inputOpt.has_value()) {
                     inputOpt->up = cmd.input.up;
                     inputOpt->down = cmd.input.down;
                     inputOpt->left = cmd.input.left;

--- a/server/tests/game/levels/testLevelSystem.cpp
+++ b/server/tests/game/levels/testLevelSystem.cpp
@@ -44,14 +44,14 @@ TEST(LevelSystem, SpawnOneWave)
 
     int spawnedCount = 0;
     for (size_t i = 0; i < posArr.size(); ++i) {
-        if (posArr[i].has_value())
+        if (posArr.at(i).has_value())
             spawnedCount++;
     }
 
     EXPECT_EQ(spawnedCount, 2);
 
     for (size_t i = 0; i < posArr.size(); ++i) {
-        if (!posArr[i].has_value())
+        if (!posArr.at(i).has_value())
             continue;
 
         EXPECT_TRUE(world.registry().hasComponent<Ecs::Velocity>(Ecs::Entity(i)));
@@ -93,14 +93,14 @@ TEST(LevelSystem, WaveTriggersOnlyOnce)
     auto &posArr = world.registry().getComponents<Ecs::Position>();
     int firstSpawnCount = 0;
     for (size_t i = 0; i < posArr.size(); ++i)
-        if (posArr[i].has_value())
+        if (posArr.at(i).has_value())
             firstSpawnCount++;
 
     Game::LevelSystem::update(world, mgr, 5.f);
 
     int secondSpawnCount = 0;
     for (size_t i = 0; i < posArr.size(); ++i)
-        if (posArr[i].has_value())
+        if (posArr.at(i).has_value())
             secondSpawnCount++;
 
     EXPECT_EQ(firstSpawnCount, secondSpawnCount);

--- a/server/tests/game/systems/testAISystem.cpp
+++ b/server/tests/game/systems/testAISystem.cpp
@@ -22,12 +22,12 @@ TEST(AISystem, idle_moves_slowly)
     reg.emplaceComponent<Ecs::Position>(e, 0.f, 0.f);
     reg.emplaceComponent<Ecs::Target>(e);
 
-    auto &tgt = reg.getComponents<Ecs::Target>()[static_cast<size_t>(e)];
+    auto &tgt = reg.getComponents<Ecs::Target>().at(static_cast<size_t>(e));
     tgt->targetId = SIZE_MAX;
 
     Game::AISystem::update(world, 0.1f);
 
-    const auto &vel = reg.getComponents<Ecs::Velocity>()[static_cast<size_t>(e)];
+    const auto &vel = reg.getComponents<Ecs::Velocity>().at(static_cast<size_t>(e));
     ASSERT_TRUE(vel.has_value());
 
     EXPECT_FLOAT_EQ(vel->vx, -20.f);
@@ -44,12 +44,12 @@ TEST(AISystem, transitions_to_patrol_after_1s)
     reg.emplaceComponent<Ecs::Position>(e, 0.f, 0.f);
     reg.emplaceComponent<Ecs::Target>(e);
 
-    auto &tgt = reg.getComponents<Ecs::Target>()[static_cast<size_t>(e)];
+    auto &tgt = reg.getComponents<Ecs::Target>().at(static_cast<size_t>(e));
     tgt->targetId = SIZE_MAX;
 
     Game::AISystem::update(world, 1.6f);
 
-    const auto &brain = reg.getComponents<Ecs::AIBrain>()[static_cast<size_t>(e)];
+    const auto &brain = reg.getComponents<Ecs::AIBrain>().at(static_cast<size_t>(e));
     ASSERT_TRUE(brain.has_value());
 
     EXPECT_EQ(brain->state, Ecs::AIState::Patrol);

--- a/server/tests/game/systems/testAttackSystem.cpp
+++ b/server/tests/game/systems/testAttackSystem.cpp
@@ -66,7 +66,7 @@ TEST(AttackSystem, shoots_projectile_when_in_attack_state)
     const size_t enemyIdx = static_cast<size_t>(enemy);
     const size_t playerIdx = static_cast<size_t>(player);
 
-    reg.getComponents<Ecs::Target>()[enemyIdx]->targetId = playerIdx;
+    reg.getComponents<Ecs::Target>().at(enemyIdx)->targetId = playerIdx;
 
     AttackSystem::update(world, 0.1f);
 
@@ -77,11 +77,11 @@ TEST(AttackSystem, shoots_projectile_when_in_attack_state)
     bool projectileFound = false;
 
     for (size_t i = 0; i < velArr.size(); ++i) {
-        if (velArr[i].has_value() && dmgArr[i].has_value() && colArr[i].has_value()) {
+        if (velArr.at(i).has_value() && dmgArr.at(i).has_value() && colArr.at(i).has_value()) {
             projectileFound = true;
-            EXPECT_FLOAT_EQ(velArr[i]->vx, 100.f);
-            EXPECT_FLOAT_EQ(velArr[i]->vy, 0.f);
-            EXPECT_EQ(dmgArr[i]->amount, 10);
+            EXPECT_FLOAT_EQ(velArr.at(i)->vx, 100.f);
+            EXPECT_FLOAT_EQ(velArr.at(i)->vy, 0.f);
+            EXPECT_EQ(dmgArr.at(i)->amount, 10);
         }
     }
 
@@ -96,16 +96,16 @@ TEST(AttackSystem, does_not_shoot_during_cooldown)
     const Ecs::Entity enemy = createEnemyWithAttack(world);
     const size_t enemyIdx = static_cast<size_t>(enemy);
 
-    reg.getComponents<Ecs::AIBrain>()[enemyIdx]->attackCooldown = 1.f;
+    reg.getComponents<Ecs::AIBrain>().at(enemyIdx)->attackCooldown = 1.f;
 
     const Ecs::Entity player = createPlayer(world, 100.f, 0.f);
-    reg.getComponents<Ecs::Target>()[enemyIdx]->targetId = static_cast<size_t>(player);
+    reg.getComponents<Ecs::Target>().at(enemyIdx)->targetId = static_cast<size_t>(player);
 
     AttackSystem::update(world, 0.1f);
 
     auto &dmgArr = reg.getComponents<Ecs::Damage>();
     for (size_t i = 0; i < dmgArr.size(); ++i)
-        EXPECT_FALSE(dmgArr[i].has_value());
+        EXPECT_FALSE(dmgArr.at(i).has_value());
 }
 
 TEST(AttackSystem, does_not_shoot_without_target)
@@ -119,7 +119,7 @@ TEST(AttackSystem, does_not_shoot_without_target)
 
     auto &dmgArr = reg.getComponents<Ecs::Damage>();
     for (size_t i = 0; i < dmgArr.size(); ++i)
-        EXPECT_FALSE(dmgArr[i].has_value());
+        EXPECT_FALSE(dmgArr.at(i).has_value());
 }
 
 TEST(AttackSystem, resets_cooldown_after_shooting)
@@ -133,12 +133,12 @@ TEST(AttackSystem, resets_cooldown_after_shooting)
     const size_t enemyIdx = static_cast<size_t>(enemy);
     const size_t playerIdx = static_cast<size_t>(player);
 
-    reg.getComponents<Ecs::Target>()[enemyIdx]->targetId = playerIdx;
+    reg.getComponents<Ecs::Target>().at(enemyIdx)->targetId = playerIdx;
 
     AttackSystem::update(world, 0.1f);
 
-    const auto &brain = *reg.getComponents<Ecs::AIBrain>()[enemyIdx];
-    const auto &atk = *reg.getComponents<Ecs::Attack>()[enemyIdx];
+    const auto &brain = *reg.getComponents<Ecs::AIBrain>().at(enemyIdx);
+    const auto &atk = *reg.getComponents<Ecs::Attack>().at(enemyIdx);
 
     EXPECT_FLOAT_EQ(brain.attackCooldown, atk.cooldown);
 }

--- a/server/tests/game/systems/testCollisionSystem.cpp
+++ b/server/tests/game/systems/testCollisionSystem.cpp
@@ -29,7 +29,7 @@ TEST(CollisionSystem, projectile_hits_enemy_and_deals_damage)
     reg.emplaceComponent<Ecs::Damage>(proj, 10);
     Game::CollisionSystem::update(world);
 
-    auto &hp = reg.getComponents<Ecs::Health>()[static_cast<size_t>(enemy)];
+    auto &hp = reg.getComponents<Ecs::Health>().at(static_cast<size_t>(enemy));
     ASSERT_TRUE(hp.has_value());
     EXPECT_EQ(hp->hp, 40);
 }
@@ -51,7 +51,7 @@ TEST(CollisionSystem, collision_works_even_if_projectile_has_lower_id)
 
     Game::CollisionSystem::update(world);
 
-    auto &hp = reg.getComponents<Ecs::Health>()[static_cast<size_t>(enemy)];
+    auto &hp = reg.getComponents<Ecs::Health>().at(static_cast<size_t>(enemy));
     ASSERT_TRUE(hp.has_value());
     EXPECT_EQ(hp->hp, 40);
 }
@@ -73,7 +73,7 @@ TEST(CollisionSystem, projectile_is_destroyed_after_collision)
 
     Game::CollisionSystem::update(world);
 
-    auto &dmg = reg.getComponents<Ecs::Damage>()[static_cast<size_t>(proj)];
+    auto &dmg = reg.getComponents<Ecs::Damage>().at(static_cast<size_t>(proj));
     EXPECT_FALSE(dmg.has_value());
 }
 
@@ -94,7 +94,7 @@ TEST(CollisionSystem, no_collision_no_damage)
 
     Game::CollisionSystem::update(world);
 
-    auto &hp = reg.getComponents<Ecs::Health>()[static_cast<size_t>(enemy)];
+    auto &hp = reg.getComponents<Ecs::Health>().at(static_cast<size_t>(enemy));
     ASSERT_TRUE(hp.has_value());
     EXPECT_EQ(hp->hp, 50);
 }
@@ -121,6 +121,6 @@ TEST(CollisionSystem, projectile_can_hit_multiple_enemies_same_frame)
 
     Game::CollisionSystem::update(world);
 
-    EXPECT_EQ(reg.getComponents<Ecs::Health>()[static_cast<size_t>(e1)]->hp, 40);
-    EXPECT_EQ(reg.getComponents<Ecs::Health>()[static_cast<size_t>(e2)]->hp, 40);
+    EXPECT_EQ(reg.getComponents<Ecs::Health>().at(static_cast<size_t>(e1))->hp, 40);
+    EXPECT_EQ(reg.getComponents<Ecs::Health>().at(static_cast<size_t>(e2))->hp, 40);
 }

--- a/server/tests/game/systems/testDamageSystem.cpp
+++ b/server/tests/game/systems/testDamageSystem.cpp
@@ -20,5 +20,5 @@ TEST(DamageSystem, removes_dead_entities)
 
     Game::DamageSystem::update(world);
 
-    EXPECT_FALSE(reg.getComponents<Ecs::Health>()[static_cast<size_t>(e)].has_value());
+    EXPECT_FALSE(reg.getComponents<Ecs::Health>().at(static_cast<size_t>(e)).has_value());
 }

--- a/server/tests/game/systems/testHealthSystem.cpp
+++ b/server/tests/game/systems/testHealthSystem.cpp
@@ -16,7 +16,7 @@ TEST(HealthSystem, destroys_entity_at_zero_hp)
     Ecs::Entity e = world.createPlayer();
 
     auto &reg = world.registry();
-    auto &hp = reg.getComponents<Ecs::Health>()[static_cast<size_t>(e)];
+    auto &hp = reg.getComponents<Ecs::Health>().at(static_cast<size_t>(e));
 
     ASSERT_TRUE(hp.has_value());
 
@@ -24,5 +24,5 @@ TEST(HealthSystem, destroys_entity_at_zero_hp)
 
     Game::HealthSystem::update(world);
 
-    EXPECT_FALSE(reg.getComponents<Ecs::Health>()[static_cast<size_t>(e)].has_value());
+    EXPECT_FALSE(reg.getComponents<Ecs::Health>().at(static_cast<size_t>(e)).has_value());
 }

--- a/server/tests/game/systems/testInputSystem.cpp
+++ b/server/tests/game/systems/testInputSystem.cpp
@@ -16,13 +16,13 @@ TEST(InputSystem, input_dont_affect_velocity)
 
     auto &reg = world.registry();
 
-    auto &input = reg.getComponents<Game::InputComponent>()[static_cast<size_t>(e)];
+    auto &input = reg.getComponents<Game::InputComponent>().at(static_cast<size_t>(e));
     input->right = true;
     input->down = true;
 
     Game::InputSystem::update(world);
 
-    auto &vel = reg.getComponents<Ecs::Velocity>()[static_cast<size_t>(e)];
+    auto &vel = reg.getComponents<Ecs::Velocity>().at(static_cast<size_t>(e));
 
     ASSERT_EQ(vel->vx, 0.f);
     ASSERT_EQ(vel->vy, 0.f);
@@ -35,15 +35,15 @@ TEST(InputSystem, diagonal_movement)
 
     auto &reg = world.registry();
 
-    auto beforePos = reg.getComponents<Ecs::Position>()[static_cast<size_t>(e)];
+    auto beforePos = reg.getComponents<Ecs::Position>().at(static_cast<size_t>(e));
 
-    auto &input = reg.getComponents<Game::InputComponent>()[static_cast<size_t>(e)];
+    auto &input = reg.getComponents<Game::InputComponent>().at(static_cast<size_t>(e));
     input->left = true;
     input->up = true;
 
     Game::InputSystem::update(world);
 
-    auto &pos = reg.getComponents<Ecs::Position>()[static_cast<size_t>(e)];
+    auto &pos = reg.getComponents<Ecs::Position>().at(static_cast<size_t>(e));
 
     ASSERT_EQ(pos->x, (beforePos->x - 7.f));
     ASSERT_EQ(pos->y, (beforePos->y - 7.f));

--- a/server/tests/game/systems/testLifetimeSystem.cpp
+++ b/server/tests/game/systems/testLifetimeSystem.cpp
@@ -20,5 +20,5 @@ TEST(LifetimeSystem, destroys_entity_after_time_expires)
 
     Game::LifetimeSystem::update(world, 0.6f);
 
-    EXPECT_FALSE(reg.getComponents<Ecs::Lifetime>()[static_cast<size_t>(e)].has_value());
+    EXPECT_FALSE(reg.getComponents<Ecs::Lifetime>().at(static_cast<size_t>(e)).has_value());
 }

--- a/server/tests/game/systems/testMovementSystem.cpp
+++ b/server/tests/game/systems/testMovementSystem.cpp
@@ -18,8 +18,8 @@ TEST(MovementSystem, moves_entities_correctly)
 
     auto &reg = world.registry();
 
-    auto &vel = reg.getComponents<Ecs::Velocity>()[static_cast<size_t>(e)];
-    auto &pos = reg.getComponents<Ecs::Position>()[static_cast<size_t>(e)];
+    auto &vel = reg.getComponents<Ecs::Velocity>().at(static_cast<size_t>(e));
+    auto &pos = reg.getComponents<Ecs::Position>().at(static_cast<size_t>(e));
 
     ASSERT_TRUE(vel.has_value());
     ASSERT_TRUE(pos.has_value());
@@ -40,8 +40,8 @@ TEST(MovementSystem, dt_affects_speed)
 
     auto &reg = world.registry();
 
-    auto &vel = reg.getComponents<Ecs::Velocity>()[static_cast<size_t>(e)];
-    auto &pos = reg.getComponents<Ecs::Position>()[static_cast<size_t>(e)];
+    auto &vel = reg.getComponents<Ecs::Velocity>().at(static_cast<size_t>(e));
+    auto &pos = reg.getComponents<Ecs::Position>().at(static_cast<size_t>(e));
 
     ASSERT_TRUE(vel.has_value());
     ASSERT_TRUE(pos.has_value());

--- a/server/tests/game/systems/testShootingSystem.cpp
+++ b/server/tests/game/systems/testShootingSystem.cpp
@@ -20,8 +20,8 @@ TEST(ShootingSystem, creates_projectile_when_shooting)
     Ecs::Entity player = world.createPlayer();
 
     auto &reg = world.registry();
-    auto &input = reg.getComponents<Game::InputComponent>()[static_cast<size_t>(player)];
-    auto &pos = reg.getComponents<Ecs::Position>()[static_cast<size_t>(player)];
+    auto &input = reg.getComponents<Game::InputComponent>().at(static_cast<size_t>(player));
+    auto &pos = reg.getComponents<Ecs::Position>().at(static_cast<size_t>(player));
 
     ASSERT_TRUE(input.has_value());
     ASSERT_TRUE(pos.has_value());
@@ -37,12 +37,12 @@ TEST(ShootingSystem, creates_projectile_when_shooting)
     bool foundProjectile = false;
 
     for (size_t i = 0; i < velArr.size(); i++) {
-        if (velArr[i].has_value() && dmgArr[i].has_value() && colArr[i].has_value()) {
+        if (velArr.at(i).has_value() && dmgArr.at(i).has_value() && colArr.at(i).has_value()) {
             foundProjectile = true;
 
-            EXPECT_FLOAT_EQ(velArr[i]->vx, 100.0f);
-            EXPECT_FLOAT_EQ(velArr[i]->vy, 0.f);
-            EXPECT_EQ(dmgArr[i]->amount, 20);
+            EXPECT_FLOAT_EQ(velArr.at(i)->vx, 100.0f);
+            EXPECT_FLOAT_EQ(velArr.at(i)->vy, 0.f);
+            EXPECT_EQ(dmgArr.at(i)->amount, 20);
         }
     }
 
@@ -55,7 +55,7 @@ TEST(ShootingSystem, resets_shoot_flag)
     Ecs::Entity player = world.createPlayer();
 
     auto &reg = world.registry();
-    auto &input = reg.getComponents<Game::InputComponent>()[static_cast<size_t>(player)];
+    auto &input = reg.getComponents<Game::InputComponent>().at(static_cast<size_t>(player));
 
     ASSERT_TRUE(input.has_value());
 

--- a/server/tests/game/systems/testTargetingSystem.cpp
+++ b/server/tests/game/systems/testTargetingSystem.cpp
@@ -47,7 +47,7 @@ TEST(TargetingSystem, no_player_no_target_assigned)
 
     TargetingSystem::update(world);
 
-    const auto &tgt = *reg.getComponents<Ecs::Target>()[static_cast<size_t>(enemy)];
+    const auto &tgt = *reg.getComponents<Ecs::Target>().at(static_cast<size_t>(enemy));
     EXPECT_EQ(tgt.targetId, SIZE_MAX);
 }
 
@@ -61,7 +61,7 @@ TEST(TargetingSystem, assigns_target_when_player_in_range)
 
     TargetingSystem::update(world);
 
-    const auto &tgt = *reg.getComponents<Ecs::Target>()[static_cast<size_t>(enemy)];
+    const auto &tgt = *reg.getComponents<Ecs::Target>().at(static_cast<size_t>(enemy));
     EXPECT_EQ(tgt.targetId, static_cast<size_t>(player));
 }
 
@@ -75,7 +75,7 @@ TEST(TargetingSystem, does_not_assign_target_when_player_out_of_range)
 
     TargetingSystem::update(world);
 
-    const auto &tgt = *reg.getComponents<Ecs::Target>()[static_cast<size_t>(enemy)];
+    const auto &tgt = *reg.getComponents<Ecs::Target>().at(static_cast<size_t>(enemy));
     EXPECT_EQ(tgt.targetId, SIZE_MAX);
 }
 
@@ -88,10 +88,10 @@ TEST(TargetingSystem, clears_target_when_player_leaves_range)
     const Ecs::Entity enemy = createEnemy(world, 0.f, 0.f, 100.f);
 
     TargetingSystem::update(world);
-    EXPECT_EQ(reg.getComponents<Ecs::Target>()[static_cast<size_t>(enemy)]->targetId, static_cast<size_t>(player));
+    EXPECT_EQ(reg.getComponents<Ecs::Target>().at(static_cast<size_t>(enemy))->targetId, static_cast<size_t>(player));
 
-    reg.getComponents<Ecs::Position>()[static_cast<size_t>(player)]->x = 300.f;
+    reg.getComponents<Ecs::Position>().at(static_cast<size_t>(player))->x = 300.f;
 
     TargetingSystem::update(world);
-    EXPECT_EQ(reg.getComponents<Ecs::Target>()[static_cast<size_t>(enemy)]->targetId, SIZE_MAX);
+    EXPECT_EQ(reg.getComponents<Ecs::Target>().at(static_cast<size_t>(enemy))->targetId, SIZE_MAX);
 }

--- a/server/tests/game/world/testWorld.cpp
+++ b/server/tests/game/world/testWorld.cpp
@@ -26,8 +26,8 @@ TEST(World, create_player_adds_all_components)
     ASSERT_TRUE(reg.hasComponent<Game::InputComponent>(e));
 
     auto &pos = reg.getComponents<Ecs::Position>();
-    ASSERT_EQ(pos[(size_t) e]->x, 100.f);
-    ASSERT_EQ(pos[(size_t) e]->y, 100.f);
+    ASSERT_EQ(pos.at((size_t) e)->x, 100.f);
+    ASSERT_EQ(pos.at((size_t) e)->y, 100.f);
 }
 
 TEST(World, destroy_player_removes_components)

--- a/shared/ecs/src/registry/Registry.tpp
+++ b/shared/ecs/src/registry/Registry.tpp
@@ -46,7 +46,7 @@ namespace Ecs
         auto idx = static_cast<size_t>(entity);
         if (idx >= arr.size())
             return false;
-        return arr[idx].has_value();
+        return arr.at(idx).has_value();
     }
 
     template <typename... Components, typename Function>
@@ -60,12 +60,12 @@ namespace Ecs
 
         for (size_t i = 0; i < maxSize; ++i) {
             const bool ok = ((i < std::get<SparseArray<Components> &>(arrays).size()
-                                 && std::get<SparseArray<Components> &>(arrays)[i].has_value())
+                                 && std::get<SparseArray<Components> &>(arrays).at(i).has_value())
                 && ...);
             if (!ok)
                 continue;
 
-            fn(Entity(i), *std::get<SparseArray<Components> &>(arrays)[i]...);
+            fn(Entity(i), *std::get<SparseArray<Components> &>(arrays).at(i)...);
         }
     }
 

--- a/shared/ecs/src/sparseArray/SparseArray.hpp
+++ b/shared/ecs/src/sparseArray/SparseArray.hpp
@@ -57,7 +57,7 @@ namespace Ecs
          * @param index Entity index
          * @return Reference to the optional component
          */
-        std::optional<Component> &operator[](size_t index);
+        std::optional<Component> &at(size_t index);
 
         /**
          * @brief Gets the current size of the sparse array.

--- a/shared/ecs/src/sparseArray/SparseArray.tpp
+++ b/shared/ecs/src/sparseArray/SparseArray.tpp
@@ -25,7 +25,7 @@ namespace Ecs
     }
 
     template <typename Component>
-    std::optional<Component> &SparseArray<Component>::operator[](size_t index)
+    std::optional<Component> &SparseArray<Component>::at(size_t index)
     {
         static std::optional<Component> empty = std::nullopt;
         if (index >= _components.size())

--- a/shared/tests/testRegistry.cpp
+++ b/shared/tests/testRegistry.cpp
@@ -75,6 +75,6 @@ TEST(Registry, view_position_velocity)
 
     auto &pos = registry.getComponents<Ecs::Position>();
 
-    ASSERT_EQ(pos[static_cast<size_t>(e1)]->x, 2.f);
-    ASSERT_EQ(pos[static_cast<size_t>(e3)]->y, 4.f);
+    ASSERT_EQ(pos.at(static_cast<size_t>(e1))->x, 2.f);
+    ASSERT_EQ(pos.at(static_cast<size_t>(e3))->y, 4.f);
 }

--- a/shared/tests/testSparseArray.cpp
+++ b/shared/tests/testSparseArray.cpp
@@ -15,8 +15,8 @@ TEST(SparseArray, insert_and_access)
     arr.insert(5, 42);
 
     ASSERT_EQ(arr.size(), 6);
-    ASSERT_TRUE(arr[5].has_value());
-    ASSERT_EQ(arr[5].value(), 42);
+    ASSERT_TRUE(arr.at(5).has_value());
+    ASSERT_EQ(arr.at(5).value(), 42);
 }
 
 TEST(SparseArray, out_of_bounds_is_empty)
@@ -24,7 +24,7 @@ TEST(SparseArray, out_of_bounds_is_empty)
     Ecs::SparseArray<int> arr;
 
     ASSERT_EQ(arr.size(), 0);
-    ASSERT_FALSE(arr[42].has_value());
+    ASSERT_FALSE(arr.at(42).has_value());
 }
 
 TEST(SparseArray, remove)
@@ -32,9 +32,9 @@ TEST(SparseArray, remove)
     Ecs::SparseArray<int> arr;
     arr.insert(3, 10);
 
-    ASSERT_TRUE(arr[3].has_value());
+    ASSERT_TRUE(arr.at(3).has_value());
 
     arr.remove(3);
 
-    ASSERT_FALSE(arr[3].has_value());
+    ASSERT_FALSE(arr.at(3).has_value());
 }


### PR DESCRIPTION
This pull request refactors access to component arrays throughout the codebase and tests, replacing direct indexing (`arr[i]`) with the safer `.at(i)` method. This change improves safety by enforcing bounds checking, reducing the risk of undefined behavior from out-of-range access. The update is applied consistently across all ECS systems and related tests.

**Core logic and systems:**

* Replaced all direct component array indexing with `.at()` in ECS systems, including AI, Attack, Collision, Damage, Health, Lifetime, Movement, Targeting, and Input systems. This ensures bounds checking and prevents potential out-of-bounds access in the main game logic. [[1]](diffhunk://#diff-f0173dfd251e24bf763d24645db7990ae77806bb3ae9a69faadeb14a647145bdL53-R53) [[2]](diffhunk://#diff-ab17b97e79120472e688e61342c8fc329faf45136a895c02dccda1d1f2b4e293L37-R40) [[3]](diffhunk://#diff-265fc99ced1a09583aa17c4d90c37bffea7ea30ac946bd192f58252e276cf6f0L30-R42) [[4]](diffhunk://#diff-9789152b1e61a682f66c47c9ec541c54847e1b34e3ad750ef5153d0272928d41L18-R21) [[5]](diffhunk://#diff-8dd455cad7d49ffe392ab171050dd419ef56d0e84b25772ec89231a777b29900L18-R20) [[6]](diffhunk://#diff-e7f6ccca4cf862ffc66a457ec4e3bf3cbaeb213395303e94710490db15e2d0e9L19-R23) [[7]](diffhunk://#diff-5321a57e46009ec17789f415ba22affad3f088b1d33d5743b244d4c8f3beba02L20-R26) [[8]](diffhunk://#diff-c7bd46cb52485f0ca8e00b03585bd7ef7c289ac3ba8bd8e0a4fdc9c4b13a2e59L150-R150)

**Test suite:**

* Updated all test cases to use `.at()` instead of direct indexing when accessing component arrays, ensuring test code matches the new, safer access pattern and will catch any out-of-bounds issues. [[1]](diffhunk://#diff-a98cc4069023280e86d8f07df39d78a6ea0ab5fc6a74a4591d1f6213dc75b798L47-R54) [[2]](diffhunk://#diff-a98cc4069023280e86d8f07df39d78a6ea0ab5fc6a74a4591d1f6213dc75b798L96-R103) [[3]](diffhunk://#diff-56d04ba833f589e39272a2ef63663964706164b88a5573d10fd8ad757516858eL25-R30) [[4]](diffhunk://#diff-56d04ba833f589e39272a2ef63663964706164b88a5573d10fd8ad757516858eL47-R52) [[5]](diffhunk://#diff-63f5be03d450f39aec2853c4e02769ea4bf3a9bd8cde7bcd1dd68a78b77b4363L69-R69) [[6]](diffhunk://#diff-63f5be03d450f39aec2853c4e02769ea4bf3a9bd8cde7bcd1dd68a78b77b4363L80-R84) [[7]](diffhunk://#diff-63f5be03d450f39aec2853c4e02769ea4bf3a9bd8cde7bcd1dd68a78b77b4363L99-R108) [[8]](diffhunk://#diff-63f5be03d450f39aec2853c4e02769ea4bf3a9bd8cde7bcd1dd68a78b77b4363L122-R122) [[9]](diffhunk://#diff-63f5be03d450f39aec2853c4e02769ea4bf3a9bd8cde7bcd1dd68a78b77b4363L136-R141) [[10]](diffhunk://#diff-6b55e4b7fbb150f8316a571b00ae0c7ce228a788a71e68e65bc4b0900016c513L32-R32) [[11]](diffhunk://#diff-6b55e4b7fbb150f8316a571b00ae0c7ce228a788a71e68e65bc4b0900016c513L54-R54) [[12]](diffhunk://#diff-6b55e4b7fbb150f8316a571b00ae0c7ce228a788a71e68e65bc4b0900016c513L76-R76) [[13]](diffhunk://#diff-6b55e4b7fbb150f8316a571b00ae0c7ce228a788a71e68e65bc4b0900016c513L97-R97) [[14]](diffhunk://#diff-6b55e4b7fbb150f8316a571b00ae0c7ce228a788a71e68e65bc4b0900016c513L124-R125) [[15]](diffhunk://#diff-740c62f7898096e7b75b20fc21de01b3059094c64214a0c8a52b46580a3323bfL23-R23) [[16]](diffhunk://#diff-e75192d0fae1f92940d708391c98c077c6647027f656eba22ec44ceda321a2a2L19-R27) [[17]](diffhunk://#diff-6dd89e19e70d12e108a9e089260dd6f589ed65e9551af8aeb6c03774aba7f4daL19-R25) [[18]](diffhunk://#diff-6dd89e19e70d12e108a9e089260dd6f589ed65e9551af8aeb6c03774aba7f4daL38-R46) [[19]](diffhunk://#diff-2316dc484068912e106c5ae8d992c625ed0ae12294426397e3c43ccaeacfcae6L23-R23) [[20]](diffhunk://#diff-c0972d07c045144b8fdb1d89aa452ac09e108b09a1274dfbcb88f1ae2acf9ea2L21-R22)

These changes collectively improve the robustness and reliability of both the core systems and the test suite by enforcing safer access patterns for component arrays.…r access