### PR TITLE
feat: handle unexpected game start closure with atomic flag

### DIFF
--- a/client/src/thread/ClientRuntime.cpp
+++ b/client/src/thread/ClientRuntime.cpp
@@ -302,9 +302,9 @@ namespace Thread
                 _udpClient->sendPacket(*_udpPacketFactory.makeConnect(_tcpPacketRouter->sink()->getConnectInfo()));
             });
 
-            _tcpPacketRouter->sink()->onGameStartSubscribe([this](uint32_t, uint32_t) {
-                _pendingGameStart.store(true, std::memory_order_release);
-            });
+        _tcpPacketRouter->sink()->onGameStartSubscribe([this](uint32_t, uint32_t) {
+            _pendingGameStart.store(true, std::memory_order_release);
+        });
 
         while (_running) {
             _tcpClient->receivePackets();

--- a/client/src/thread/ClientRuntime.hpp
+++ b/client/src/thread/ClientRuntime.hpp
@@ -228,7 +228,6 @@ namespace Thread
          * @brief Atomic flag to indicate if a game start has been requested.
          */
         std::atomic_bool _pendingGameStart{false};
-
     };
 
 } // namespace Thread


### PR DESCRIPTION
This pull request refactors how the game start event is handled in the `ClientRuntime` class to improve thread safety and decouple network event handling from the main display loop. The main change is the introduction of an atomic flag to signal a pending game start, which is now processed in the display thread instead of directly in the TCP thread.

**Game start event handling improvements:**

* Added an atomic flag `_pendingGameStart` to `ClientRuntime` to safely signal when a game start has been requested across threads. (`client/src/thread/ClientRuntime.hpp`, [client/src/thread/ClientRuntime.hppL225-R231](diffhunk://#diff-4a5a51be5ed4b64902b2060c1cb4362c8fa31c116959008ab5bde433834ab140L225-R231))
* Modified the TCP thread (`runTcp`) to set the `_pendingGameStart` flag instead of directly changing the game state when a game start event is received. (`client/src/thread/ClientRuntime.cpp`, [client/src/thread/ClientRuntime.cppL291-R306](diffhunk://#diff-440028e10c126fc68157cebb5f7dea671860bdde45b79e8c1e91810cd098f285L291-R306))
* Updated the display thread loop to check and process the `_pendingGameStart` flag, safely transitioning to the `GameState` and handling exceptions. (`client/src/thread/ClientRuntime.cpp`, [client/src/thread/ClientRuntime.cppR123-R129](diffhunk://#diff-440028e10c126fc68157cebb5f7dea671860bdde45b79e8c1e91810cd098f285R123-R129))

**Thread safety and code clarity:**

* Removed the `const` qualifier from `runTcp` since it now modifies the `_pendingGameStart` flag. (`client/src/thread/ClientRuntime.cpp`, [client/src/thread/ClientRuntime.cppL291-R306](diffhunk://#diff-440028e10c126fc68157cebb5f7dea671860bdde45b79e8c1e91810cd098f285L291-R306))
* Added documentation for the new atomic flag in the class header. (`client/src/thread/ClientRuntime.hpp`, [client/src/thread/ClientRuntime.hppL225-R231](diffhunk://#diff-4a5a51be5ed4b64902b2060c1cb4362c8fa31c116959008ab5bde433834ab140L225-R231))