### PR TITLE
fix: The linter on shared folder

### DIFF
--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -39,7 +39,7 @@ while IFS= read -r -d '' f; do
         FORMAT_ERRORS=1
         echo -e "${YELLOW}Needs format: $f${NC}"
     fi
-done < <(find client/src server/src shared -name "*.cpp" -o -name "*.hpp" -print0)
+done < <(find client server  shared \( -name "*.cpp" -o -name "*.hpp"  -o -name "*.tpp" \) -print0)
 
 [[ $FORMAT_ERRORS -eq 0 ]] && \
     echo -e "${GREEN}Format OK${NC}" || \

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -27,7 +27,7 @@ echo "==================================="
 ###############################################
 # APPLY clang-format
 ###############################################
-find client/src server/src shared \( -name "*.cpp" -o -name "*.hpp" \) -print0 \
+find client server shared -name "*.cpp" -o -name "*.hpp" -o -name "*.tpp" -print0 \
     | xargs -0 clang-format-20 -i
 
 echo -e "${GREEN}Format applied${NC}"


### PR DESCRIPTION
This pull request updates the linting scripts to include the `shared` directory in formatting checks and automatic formatting. This ensures that C++ files in `shared` are now consistently checked and formatted alongside those in `client/src` and `server/src`.

**Linting and formatting script updates:**

* Updated `scripts/lint-check.sh` to include the `shared` directory when searching for `.cpp` and `.hpp` files to check for formatting issues.
* Updated `scripts/lint-fix.sh` to apply `clang-format` to `.cpp` and `.hpp` files in the `shared` directory as well.